### PR TITLE
Use smaller base Python image for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.10-alpine
 WORKDIR /app
 
 RUN pip install uv==0.6.6 --no-cache-dir


### PR DESCRIPTION
This will result in smaller Docker image when building.