### PR TITLE
Fix where rebuilding Docker image doesn't carry source code changes

### DIFF
--- a/run-linux-docker.sh
+++ b/run-linux-docker.sh
@@ -11,4 +11,4 @@ sudo docker volume create hooyootracker_data
 # Run the HooYooTracker package
 echo "Starting HooYooTracker..."
 echo
-sudo docker run -q -p 8080:8080 -q -v hooyootracker_data:/app hooyootracker
+sudo docker run -q -p 8080:8080 -q -v hooyootracker_data:/app/program_data hooyootracker

--- a/run-windows-docker.bat
+++ b/run-windows-docker.bat
@@ -11,6 +11,6 @@ docker volume create hooyootracker_data >nul 2>&1
 :: Run the HooYooTracker through Docker
 echo Starting HooYooTracker...
 echo.
-docker run -q -p 8080:8080 -q -v hooyootracker_data:/app hooyootracker
+docker run -q -p 8080:8080 -q -v hooyootracker_data:/app/program_data hooyootracker
 
 pause


### PR DESCRIPTION
If you are a Docker user of this app, I suggest that you recreate the volume manually so that you can run the `run-windows-docker.bat` or `run-linux-docker.sh` properly.

Resolves #32 