### PR TITLE
Add Snackbar component for showing quick updates

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,7 +30,8 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router": "^7.13.1",
-    "tailwindcss": "^4.2.1"
+    "tailwindcss": "^4.2.1",
+    "zustand": "^5.0.11"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,7 @@ import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client
 import { BrowserRouter, Route, Routes } from "react-router";
 import "./App.css";
 import { GenericLayout } from "./components/layout/GenericLayout";
+import { Snackbar } from "./components/ui/snackbar/Snackbar";
 import { Home } from "./features/home";
 import { ROUTES } from "./route";
 import { persister, queryClient } from "./state_management/react_query";
@@ -12,6 +13,7 @@ function App() {
       client={queryClient}
       persistOptions={{ persister, maxAge: Infinity }}
     >
+      <Snackbar />
       <BrowserRouter>
         <Routes>
           <Route path={ROUTES.HOME}>

--- a/apps/web/src/components/ui/snackbar/Snackbar.tsx
+++ b/apps/web/src/components/ui/snackbar/Snackbar.tsx
@@ -5,7 +5,8 @@ import clsx from "clsx";
 import { useSnackbarStore } from "../../../state_management/store/useSnackbarStore";
 
 export function Snackbar() {
-  const { message, open, hide, status, action, showDismiss } = useSnackbarStore();
+  const { message, open, hide, status, action, showDismiss } =
+    useSnackbarStore();
 
   if (!open) return null;
 
@@ -13,7 +14,7 @@ export function Snackbar() {
     <div
       className={clsx(
         "flex flex-row fixed items-center rounded-lg",
-        "left-1/2 -translate-x-1/2 z-10 bottom-8 w-96 pt-3 pb-3 pl-4 pr-4 gap-4",
+        "left-1/2 -translate-x-1/2 z-10 bottom-8 w-[90%] max-w-96 pt-3 pb-3 pl-4 pr-4 gap-4",
         "bg-md-inverse-surface text-md-inverse-on-surface rounded-lg",
         "shadow-md-shadow",
       )}

--- a/apps/web/src/components/ui/snackbar/Snackbar.tsx
+++ b/apps/web/src/components/ui/snackbar/Snackbar.tsx
@@ -5,7 +5,7 @@ import clsx from "clsx";
 import { useSnackbarStore } from "../../../state_management/store/useSnackbarStore";
 
 export function Snackbar() {
-  const { message, open, hide, status, showDismiss } = useSnackbarStore();
+  const { message, open, hide, status, action, showDismiss } = useSnackbarStore();
 
   if (!open) return null;
 
@@ -19,8 +19,8 @@ export function Snackbar() {
       )}
     >
       {status === "success" && (
-        <div className="text-md-on-inverse-surface">
-          <CheckCircleIcon />
+        <div className="flex text-md-on-inverse-surface text-2xl">
+          <CheckCircleIcon fontSize="inherit" />
         </div>
       )}
       {status === "processing" && (
@@ -29,11 +29,22 @@ export function Snackbar() {
         </div>
       )}
       {status === "error" && (
-        <div className="text-md-on-inverse-surface">
-          <ErrorIcon />
+        <div className="flex text-md-on-inverse-surface text-2xl">
+          <ErrorIcon fontSize="inherit" />
         </div>
       )}
       <p className="text-sm text-wrap break-all">{message}</p>
+      {action && (
+        <button
+          className={clsx(
+            "ml-auto text-sm text-md-inverse-primary min-w-fit -mt-0.5",
+            "cursor-pointer hover:text-md-inverse-primary/62 transition-all",
+          )}
+          onClick={action.handler}
+        >
+          {action.name}
+        </button>
+      )}
       {showDismiss && <DismissButton onClick={hide} />}
     </div>
   );
@@ -55,7 +66,7 @@ function DismissButton({ onClick }: { onClick: () => void }) {
   return (
     <button
       className={clsx(
-        "ml-auto text-sm text-md-inverse-on-surface min-w-fit",
+        "flex ml-auto text-sm text-md-inverse-on-surface min-w-fit",
         "cursor-pointer hover:text-md-inverse-on-surface/62 transition-all",
       )}
       onClick={onClick}

--- a/apps/web/src/components/ui/snackbar/Snackbar.tsx
+++ b/apps/web/src/components/ui/snackbar/Snackbar.tsx
@@ -1,10 +1,11 @@
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import CloseIcon from "@mui/icons-material/Close";
 import ErrorIcon from "@mui/icons-material/Error";
 import clsx from "clsx";
 import { useSnackbarStore } from "../../../state_management/store/useSnackbarStore";
 
 export function Snackbar() {
-  const { message, open, status } = useSnackbarStore();
+  const { message, open, hide, status, showDismiss } = useSnackbarStore();
 
   if (!open) return null;
 
@@ -12,7 +13,7 @@ export function Snackbar() {
     <div
       className={clsx(
         "flex flex-row fixed items-center rounded-lg",
-        "left-1/2 -translate-x-1/2 z-10 bottom-8 w-96 h-12 p-4 gap-4",
+        "left-1/2 -translate-x-1/2 z-10 bottom-8 w-96 pt-3 pb-3 pl-4 pr-4 gap-4",
         "bg-md-inverse-surface text-md-inverse-on-surface rounded-lg",
         "shadow-md-shadow",
       )}
@@ -23,7 +24,7 @@ export function Snackbar() {
         </div>
       )}
       {status === "processing" && (
-        <div className="w-6">
+        <div className="w-6 min-w-6">
           <Spinner />
         </div>
       )}
@@ -32,7 +33,8 @@ export function Snackbar() {
           <ErrorIcon />
         </div>
       )}
-      <p className="text-sm">{message}</p>
+      <p className="text-sm text-wrap break-all">{message}</p>
+      {showDismiss && <DismissButton onClick={hide} />}
     </div>
   );
 }
@@ -46,5 +48,19 @@ function Spinner() {
       )}
       viewBox="0 0 24 24"
     ></svg>
+  );
+}
+
+function DismissButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      className={clsx(
+        "ml-auto text-sm text-md-inverse-on-surface min-w-fit",
+        "cursor-pointer hover:text-md-inverse-on-surface/62 transition-all",
+      )}
+      onClick={onClick}
+    >
+      <CloseIcon />
+    </button>
   );
 }

--- a/apps/web/src/components/ui/snackbar/Snackbar.tsx
+++ b/apps/web/src/components/ui/snackbar/Snackbar.tsx
@@ -1,0 +1,50 @@
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorIcon from "@mui/icons-material/Error";
+import clsx from "clsx";
+import { useSnackbarStore } from "../../../state_management/store/useSnackbarStore";
+
+export function Snackbar() {
+  const { message, open, status } = useSnackbarStore();
+
+  if (!open) return null;
+
+  return (
+    <div
+      className={clsx(
+        "flex flex-row fixed items-center rounded-lg",
+        "left-1/2 -translate-x-1/2 z-10 bottom-8 w-96 h-12 p-4 gap-4",
+        "bg-md-inverse-surface text-md-inverse-on-surface rounded-lg",
+        "shadow-md-shadow",
+      )}
+    >
+      {status === "success" && (
+        <div className="text-md-on-inverse-surface">
+          <CheckCircleIcon />
+        </div>
+      )}
+      {status === "processing" && (
+        <div className="w-6">
+          <Spinner />
+        </div>
+      )}
+      {status === "error" && (
+        <div className="text-md-on-inverse-surface">
+          <ErrorIcon />
+        </div>
+      )}
+      <p className="text-sm">{message}</p>
+    </div>
+  );
+}
+
+function Spinner() {
+  return (
+    <svg
+      className={clsx(
+        "animate-spin border-md-inverse-on-surface border-t-transparent",
+        "rounded-full border-4",
+      )}
+      viewBox="0 0 24 24"
+    ></svg>
+  );
+}

--- a/apps/web/src/constants.ts
+++ b/apps/web/src/constants.ts
@@ -1,0 +1,16 @@
+export const APP = {
+  NAME: "HooYooTracker",
+};
+
+export const GAME_CONFIG = {
+  "Genshin Impact": {
+    query: "gi",
+    redeemBaseUrl: "https://genshin.hoyoverse.com/en/gift?code=",
+  },
+  "Zenless Zone Zero": {
+    query: "zzz",
+    redeemBaseUrl: "https://zenless.hoyoverse.com/redemption?code=",
+  },
+} as const;
+
+export const GAME_LIST = Object.keys(GAME_CONFIG) as Array<keyof typeof GAME_CONFIG>;

--- a/apps/web/src/constants.tsx
+++ b/apps/web/src/constants.tsx
@@ -1,3 +1,0 @@
-export const APP = {
-  NAME: "HooYooTracker",
-}

--- a/apps/web/src/features/home/index.tsx
+++ b/apps/web/src/features/home/index.tsx
@@ -1,24 +1,24 @@
+import type { APIResult } from "@hooyootracker/core";
+import RefreshIcon from "@mui/icons-material/Refresh";
 import CircularProgress from "@mui/material/CircularProgress";
+import clsx from "clsx";
 import { useState } from "react";
 import { Content } from "../../components/layout/Content";
 import { Card } from "../../components/ui/Card";
 import { FilterChip } from "../../components/ui/FilterChip";
+import IconButton from "../../components/ui/IconButton";
 import { Spacer } from "../../components/ui/Spacer";
-import {
-  useFetchCodes,
-  type FetchedCodeContext,
-} from "../../hooks/useFetchCodes";
+import { GAME_CONFIG, GAME_LIST } from "../../constants";
+import { useElapsedTime } from "../../hooks/useElapsedTime";
+import { useFetchCodes } from "../../hooks/useFetchCodes";
 import usePageTitle from "../../hooks/usePageTitle";
+import { useSnackbarStore } from "../../state_management/store/useSnackbarStore";
 import type { Games } from "../../types";
 import { formatTimeAndDate } from "../../utils";
-import RefreshIcon from "@mui/icons-material/Refresh";
-import IconButton from "../../components/ui/IconButton";
-import { useElapsedTime } from "../../hooks/useElapsedTime";
-import clsx from "clsx";
 
 export function Home() {
   const [game, setGame] = useState<Games>("Genshin Impact");
-  const { gi, zzz, refetch } = useFetchCodes(game);
+  const { data, error, refetch, isLoading, isRefetching } = useFetchCodes(game);
 
   usePageTitle("Home");
 
@@ -33,27 +33,31 @@ export function Home() {
         <RefreshButton onClick={() => refetch()} />
       </div>
       <Spacer size="2rem" />
-      {game === "Genshin Impact" && <CodeList context={gi} game={game} />}
-      {game === "Zenless Zone Zero" && <CodeList context={zzz} game={game} />}
+      <CodeList
+        data={data}
+        error={error}
+        game={game}
+        isLoading={isLoading}
+        isRefetching={isRefetching}
+      />
     </Content>
   );
 }
 
 function CodeList({
-  context,
+  data,
+  error,
   game,
+  isLoading,
+  isRefetching,
 }: {
-  context: FetchedCodeContext;
+  data: APIResult | undefined;
+  error: Error | null;
   game: Games;
+  isLoading: boolean;
+  isRefetching: boolean;
 }) {
-  const { result, error, isLoading, isRefetching } = context;
-  const getLink = (code: string) => {
-    if (game === "Genshin Impact") {
-      return `https://genshin.hoyoverse.com/en/gift?code=${code}`;
-    } else if (game === "Zenless Zone Zero") {
-      return `https://zenless.hoyoverse.com/redemption?code=${code}`;
-    }
-  };
+  const redeemBaseUrl = GAME_CONFIG[game].redeemBaseUrl;
 
   if (isLoading || isRefetching) {
     return (
@@ -71,7 +75,7 @@ function CodeList({
     );
   }
 
-  if (!result || result.codes.length === 0) {
+  if (!data || data.codes.length === 0) {
     return (
       <Card>
         <p>No codes available for {game}.</p>
@@ -81,31 +85,31 @@ function CodeList({
 
   return (
     <div className="flex flex-col gap-4">
-      <LastFetched date={result.date} />
+      <LastFetched date={data.date} />
       <div className="grid sm:grid-cols-2 gap-4">
-        {result.codes.map((res) => (
-          <Card key={res.code} className="gap-4">
+        {data.codes.map((entry) => (
+          <Card key={entry.code} className="gap-4">
             <div className="flex flex-col">
               <a
                 className="text-xl font-bold hover:cursor-pointer hover:text-md-on-background/62 transition-all"
-                href={getLink(res.code)}
+                href={`${redeemBaseUrl}${entry.code}`}
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                {res.code}
+                {entry.code}
               </a>
-              <p>{res.description}</p>
+              <p>{entry.description}</p>
             </div>
             <a
               className={clsx(
                 "text-sm mt-auto hover:cursor-pointer text-md-on-surface-variant",
-                "hover:text-md-on-surface-variant/62 transition-all"
+                "hover:text-md-on-surface-variant/62 transition-all",
               )}
-              href={res.source.url}
+              href={entry.source.url}
               target="_blank"
               rel="noopener noreferrer"
             >
-              Source: {res.source.name}
+              Source: {entry.source.name}
             </a>
           </Card>
         ))}
@@ -135,16 +139,14 @@ function Filters({
 }) {
   return (
     <div className="flex flex-row flex-wrap gap-2">
-      <FilterChip
-        label="Genshin Impact"
-        selected={selectedFilter === "Genshin Impact"}
-        onClick={() => onSelect("Genshin Impact")}
-      />
-      <FilterChip
-        label="Zenless Zone Zero"
-        selected={selectedFilter === "Zenless Zone Zero"}
-        onClick={() => onSelect("Zenless Zone Zero")}
-      />
+      {GAME_LIST.map((game) => (
+        <FilterChip
+          key={game}
+          label={game}
+          selected={selectedFilter === game}
+          onClick={() => onSelect(game)}
+        />
+      ))}
     </div>
   );
 }

--- a/apps/web/src/features/home/index.tsx
+++ b/apps/web/src/features/home/index.tsx
@@ -35,10 +35,13 @@ export function Home() {
           onClick={() =>
             refetch({
               onRefetch: () =>
-                showSnackbar("Refreshing codes...", "processing"),
+                showSnackbar("Refreshing codes...", { status: "processing" }),
               onSuccess: () =>
-                showSnackbar("Codes refreshed successfully!", "success"),
-              onError: () => showSnackbar("Failed to refresh codes.", "error"),
+                showSnackbar("Codes refreshed successfully!", {
+                  status: "success",
+                }),
+              onError: () =>
+                showSnackbar("Failed to refresh codes.", { status: "error" }),
             })
           }
         />

--- a/apps/web/src/features/home/index.tsx
+++ b/apps/web/src/features/home/index.tsx
@@ -19,6 +19,7 @@ import { formatTimeAndDate } from "../../utils";
 export function Home() {
   const [game, setGame] = useState<Games>("Genshin Impact");
   const { data, error, refetch, isLoading, isRefetching } = useFetchCodes(game);
+  const showSnackbar = useSnackbarStore((state) => state.show);
 
   usePageTitle("Home");
 
@@ -30,7 +31,17 @@ export function Home() {
           <Spacer size="0.5rem" />
           <Filters selectedFilter={game} onSelect={setGame} />
         </div>
-        <RefreshButton onClick={() => refetch()} />
+        <RefreshButton
+          onClick={() =>
+            refetch({
+              onRefetch: () =>
+                showSnackbar("Refreshing codes...", "processing"),
+              onSuccess: () =>
+                showSnackbar("Codes refreshed successfully!", "success"),
+              onError: () => showSnackbar("Failed to refresh codes.", "error"),
+            })
+          }
+        />
       </div>
       <Spacer size="2rem" />
       <CodeList

--- a/apps/web/src/hooks/useFetchCodes.tsx
+++ b/apps/web/src/hooks/useFetchCodes.tsx
@@ -1,70 +1,55 @@
 import type { APIResult } from "@hooyootracker/core";
 import { useQuery } from "@tanstack/react-query";
+import { GAME_CONFIG } from "../constants";
 import { getCodes } from "../services/local/service";
 import type { Games } from "../types";
 
 export type FetchedCodeContext = {
   result: APIResult | undefined;
   error: Error | null;
-  refetch: () => void;
-  isLoading: boolean;
-  isRefetching: boolean;
+};
+
+type RefetchCallbacks = {
+  onRefetch?: () => void;
+  onSuccess?: () => void;
+  onError?: () => void;
 };
 
 export function useFetchCodes(selectedGame: Games) {
-  const {
-    data: gi,
-    error: giError,
-    refetch: giRefetch,
-    isLoading: giisLoading,
-    isRefetching: giIsRefetching,
-  } = useQuery({
-    queryKey: ["codes", "gi"],
-    queryFn: () => getCodes("gi"),
-    enabled: selectedGame === "Genshin Impact",
-    retry: (failureCount) => {
-      return failureCount < 0;
-    },
-  });
+  const selectedConfig = GAME_CONFIG[selectedGame];
 
   const {
-    data: zzz,
-    error: zzzError,
-    refetch: zzzRefetch,
-    isLoading: zzzIsLoading,
-    isRefetching: zzzIsRefetching,
-  } = useQuery({
-    queryKey: ["codes", "zzz"],
-    queryFn: () => getCodes("zzz"),
-    enabled: selectedGame === "Zenless Zone Zero",
-    retry: (failureCount) => {
-      return failureCount < 0;
-    },
+    data,
+    error,
+    refetch: queryRefetch,
+    isLoading,
+    isRefetching,
+  } = useQuery<APIResult, Error>({
+    queryKey: ["codes", selectedConfig.query],
+    queryFn: () => getCodes(selectedConfig.query),
+    retry: 1,
   });
 
-  const refetch = () => {
-    if (selectedGame === "Genshin Impact") {
-      giRefetch();
+  const refetch = async ({
+    onRefetch,
+    onSuccess,
+    onError,
+  }: RefetchCallbacks) => {
+    onRefetch?.();
+    const refreshResult = await queryRefetch();
+
+    if (refreshResult.error) {
+      onError?.();
     } else {
-      zzzRefetch();
+      onSuccess?.();
     }
   };
 
   return {
-    gi: {
-      result: gi,
-      error: giError,
-      isLoading: giisLoading,
-      isRefetching: giIsRefetching,
-      refetch: giRefetch,
-    },
-    zzz: {
-      result: zzz,
-      error: zzzError,
-      isLoading: zzzIsLoading,
-      isRefetching: zzzIsRefetching,
-      refetch: zzzRefetch,
-    },
+    data,
+    error,
     refetch,
+    isLoading,
+    isRefetching,
   };
 }

--- a/apps/web/src/state_management/store/useSnackbarStore.tsx
+++ b/apps/web/src/state_management/store/useSnackbarStore.tsx
@@ -1,0 +1,44 @@
+import { create } from "zustand";
+
+type Status = "success" | "processing" | "error" | "info";
+
+type SnackbarState = {
+  message: string | null;
+  open: boolean;
+  status: Status;
+  show: (message: string, status?: Status, duration?: number) => void;
+  hide: () => void;
+};
+
+let timeout: ReturnType<typeof setTimeout> | null = null;
+
+export const useSnackbarStore = create<SnackbarState>((set) => ({
+  message: null,
+  open: false,
+  status: "info",
+
+  show: (message, status, duration = 3000) => {
+    if (timeout) clearTimeout(timeout);
+
+    set({
+      message,
+      open: true,
+      status: status || "info",
+    });
+
+    if (status !== "processing") {
+      timeout = setTimeout(() => {
+        set({
+          open: false,
+          message: null,
+        });
+      }, duration);
+    }
+  },
+
+  hide: () =>
+    set({
+      open: false,
+      message: null,
+    }),
+}));

--- a/apps/web/src/state_management/store/useSnackbarStore.tsx
+++ b/apps/web/src/state_management/store/useSnackbarStore.tsx
@@ -6,8 +6,22 @@ type SnackbarState = {
   message: string | null;
   open: boolean;
   status: Status;
-  show: (message: string, status?: Status, duration?: number) => void;
+  showDismiss?: boolean;
+  show: (message: string, options?: SnackbarOptions) => void;
   hide: () => void;
+};
+
+type SnackbarOptions = {
+  status?: Status;
+  duration?: number;
+  showDismiss?: boolean;
+};
+
+const snackbarDefaultState = {
+  message: null,
+  open: false,
+  status: "info" as Status,
+  showDismiss: false,
 };
 
 let timeout: ReturnType<typeof setTimeout> | null = null;
@@ -16,29 +30,31 @@ export const useSnackbarStore = create<SnackbarState>((set) => ({
   message: null,
   open: false,
   status: "info",
+  showDismiss: false,
 
-  show: (message, status, duration = 3000) => {
+  show: (message, options?: SnackbarOptions) => {
     if (timeout) clearTimeout(timeout);
+
+    const status = options?.status ?? "info";
+    const duration = options?.duration ?? 3000;
+    const showDismiss = options?.showDismiss ?? false;
 
     set({
       message,
       open: true,
-      status: status || "info",
+      status,
+      showDismiss,
     });
 
     if (status !== "processing") {
       timeout = setTimeout(() => {
-        set({
-          open: false,
-          message: null,
-        });
+        set(snackbarDefaultState);
       }, duration);
     }
   },
 
-  hide: () =>
-    set({
-      open: false,
-      message: null,
-    }),
+  hide: () => {
+    if (timeout) clearTimeout(timeout);
+    set(snackbarDefaultState);
+  },
 }));

--- a/apps/web/src/state_management/store/useSnackbarStore.tsx
+++ b/apps/web/src/state_management/store/useSnackbarStore.tsx
@@ -6,6 +6,7 @@ type SnackbarState = {
   message: string | null;
   open: boolean;
   status: Status;
+  action?: Action;
   showDismiss?: boolean;
   show: (message: string, options?: SnackbarOptions) => void;
   hide: () => void;
@@ -14,8 +15,14 @@ type SnackbarState = {
 type SnackbarOptions = {
   status?: Status;
   duration?: number;
+  action?: Action;
   showDismiss?: boolean;
 };
+
+type Action = {
+  name: string;
+  handler: () => void;
+}
 
 const snackbarDefaultState = {
   message: null,
@@ -38,12 +45,14 @@ export const useSnackbarStore = create<SnackbarState>((set) => ({
     const status = options?.status ?? "info";
     const duration = options?.duration ?? 3000;
     const showDismiss = options?.showDismiss ?? false;
+    const action = options?.action;
 
     set({
       message,
       open: true,
       status,
       showDismiss,
+      action,
     });
 
     if (status !== "processing") {

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,0 +1,4 @@
+import type { GAME_CONFIG } from "./constants";
+
+export type Games = keyof typeof GAME_CONFIG;
+export type GameQuery = (typeof GAME_CONFIG)[Games]["query"];

--- a/apps/web/src/types.tsx
+++ b/apps/web/src/types.tsx
@@ -1,1 +1,0 @@
-export type Games = "Genshin Impact" | "Zenless Zone Zero";

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,8 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router": "^7.13.1",
-        "tailwindcss": "^4.2.1"
+        "tailwindcss": "^4.2.1",
+        "zustand": "^5.0.11"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -8557,6 +8558,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
+      "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "packages/config": {


### PR DESCRIPTION
## Summary

This adds a new component called `Snackbar` that shows short, meaningful details about a certain action at the bottom of the screen. I think it is important to have this so that you know the progress of a certain event. In this PR,  I add two snackbars:
- when you are refetching the data
- when the result of refetching is either successful or has failed

Also in this PR, I made a bit unrelated change wherein the `useFetchCodes` hook has been refactored because there are a lot of unnecessary repetition happening there, as well as the `Home` component that uses it.