### PR TITLE
Update app deps to latest safe versions

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@hooyootracker/core": "^1.0.0",
-    "axios": "1.14.0",
+    "axios": "1.15.0",
     "cheerio": "^1.2.0",
     "cors": "^2.8.6",
     "express": "^5.2.1"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,7 +25,7 @@
     "@tanstack/query-async-storage-persister": "^5.90.24",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-query-persist-client": "^5.90.24",
-    "axios": "^1.13.6",
+    "axios": "1.15.0",
     "clsx": "^2.1.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "license": "MIT",
       "dependencies": {
         "@hooyootracker/core": "^1.0.0",
-        "axios": "1.14.0",
+        "axios": "1.15.0",
         "cheerio": "^1.2.0",
         "cors": "^2.8.6",
         "express": "^5.2.1"
@@ -63,7 +63,7 @@
         "@tanstack/query-async-storage-persister": "^5.90.24",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-query-persist-client": "^5.90.24",
-        "axios": "^1.13.6",
+        "axios": "1.15.0",
         "clsx": "^2.1.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -3460,9 +3460,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -4125,9 +4125,9 @@
       "license": "MIT"
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8168,9 +8168,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",


### PR DESCRIPTION
### Changes
- Version pin `axios` to v1.15.0 due to reported vulnerability [(CVE-2025-62718)](https://github.com/advisories/GHSA-3p68-rc4w-qgx5)
- Update `vite` from v7.3.1 to v7.3.2 due to reported vulnerability [(CVE-2026-39364)](https://github.com/advisories/GHSA-v2wj-q39q-566r)
- Update `defu` from v6.1.4 to v6.1.7 due to reported vulnerability [(CVE-2026-35209)](https://github.com/advisories/GHSA-737v-mqg7-c878)